### PR TITLE
buildエラー回避のためresultページ修正

### DIFF
--- a/src/app/kamokamo/hairQuality/hairQuestionYou/diagnostic-imaging/result/page.jsx
+++ b/src/app/kamokamo/hairQuality/hairQuestionYou/diagnostic-imaging/result/page.jsx
@@ -1,4 +1,6 @@
 "use client";
+export const dynamic = "force-dynamic";
+
 import { useRouter, useSearchParams } from 'next/navigation';
 import React from 'react';
 import {


### PR DESCRIPTION
## ビルドエラーまとめ
```
Export encountered an error on /kamokamo/hairQuality/hairQuestionYou/diagnostic-imaging/result
```
/result/page.jsx が SSG（静的生成）中にエラーを出したようです。

## 原因
原因：useSearchParams() が build 時に実行されてしまう
useSearchParams() は クライアントサイド限定のHookですが、ビルド時はNext.jsが/resultページをサーバー側で事前にレンダリングしようとするため、そこで落ちます。

## 対応方法
このページは**"use client" + CSR（クライアントサイドレンダリング）限定にすべきページ**なので、以下の対策をとります。
方法A：エラーのあるページだけ dynamic = "force-dynamic" に設定する
```
// src/app/kamokamo/hairQuality/hairQuestionYou/diagnostic-imaging/result/page.jsx
export const dynamic = "force-dynamic";
```