### PR TITLE
buildエラー回避のためresultページ修正その２

### DIFF
--- a/src/app/kamokamo/hairQuality/hairQuestionYou/diagnostic-imaging/result/page.jsx
+++ b/src/app/kamokamo/hairQuality/hairQuestionYou/diagnostic-imaging/result/page.jsx
@@ -35,8 +35,13 @@ function ResultPage() {
 
   const rawAnswer = searchParams.get("answer");
   let parsedAnswer = null;
+
+  // 防御的なJSONパース処理を追加
   try {
-    parsedAnswer = JSON.parse(JSON.parse(rawAnswer).answer); // 二重JSONを解凍
+    if (rawAnswer) {
+      const firstParse = JSON.parse(rawAnswer);
+      parsedAnswer = JSON.parse(firstParse.answer);
+    }
   } catch (e) {
     console.error("診断データの読み取りに失敗しました", e);
   }


### PR DESCRIPTION
## ビルドエラー内容
```
Error occurred prerendering page "/kamokamo/hairQuality/hairQuestionYou/diagnostic-imaging/result". Read more: https://nextjs.org/docs/messages/prerender-error
Export encountered an error on /kamokamo/hairQuality/hairQuestionYou/diagnostic-imaging/result/page: /kamokamo/hairQuality/hairQuestionYou/diagnostic-imaging/result, exiting the build.
 ⨯ Static worker exited with code: 1 and signal: null
Error: Process completed with exit code 1.
```

## 想定される原因（new）
❗ searchParams.get("answer") が null になると JSON.parse(null) でクラッシュ
この部分、rawAnswer が null のときに JSON.parse(null) が実行されると、ビルド中に例外で落ちます（たとえクライアント用でも、Next.jsのstatic exportは一度仮レンダリングを試みます）。

## なぜローカルで動いても本番でコケる？
Next.jsのビルドでは、next export 時に全ページを**静的に一度「仮描画」**してみるため、ここで null からの JSON.parse() があると失敗します。

## 対策
防御的に rawAnswer をチェック

## 修正後（防御的に書く）
```
if (rawAnswer) {
  const firstParse = JSON.parse(rawAnswer);
  parsedAnswer = JSON.parse(firstParse.answer);
}
```
answer パラメータが存在しているときだけ解析を試みる処理を追加
存在しなければ parsedAnswer は null のまま → 初期値が使われる（今の設計と同じ）
